### PR TITLE
Replacing StringIO with io.StringIO

### DIFF
--- a/pyperform/thread.py
+++ b/pyperform/thread.py
@@ -2,7 +2,7 @@ __author__ = 'calvin'
 
 import cProfile
 import logging
-import StringIO
+from io import StringIO
 import os
 import pstats
 import sys
@@ -118,5 +118,3 @@ class LoggedThread(BaseThread):
             if LoggedThread.exception_callback:
                 e_type, e_value, last_traceback = sys.exc_info()
                 LoggedThread.exception_callback(e_type, e_value, last_traceback)
-
-


### PR DESCRIPTION
The `StringIO` module is not available on Python 3.

I'm not sure if this doesn't break anything as there isn't a test suite.
