### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyperform/cprofile_parser.py
+++ b/pyperform/cprofile_parser.py
@@ -95,7 +95,7 @@ class cProfileFuncStat(object):
 
 class cProfileParser(object):
     """
-    A manager class that reads in a pstats file and allows futher decontruction of the statistics.
+    A manager class that reads in a pstats file and allows further deconstruction of the statistics.
     """
     def __init__(self, pstats_file):
         self.path = pstats_file


### PR DESCRIPTION
There are small typos in:
- pyperform/cprofile_parser.py

Fixes:
- Should read `further` rather than `futher`.
- Should read `deconstruction` rather than `decontruction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md